### PR TITLE
Use instances of Mapping rather than dict in subs

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1,5 +1,6 @@
 """Base class for all the objects in SymPy"""
 from __future__ import print_function, division
+from collections import Mapping
 
 from .assumptions import BasicMeta, ManagedProperties
 from .cache import cacheit
@@ -833,7 +834,7 @@ class Basic(with_metaclass(ManagedProperties)):
             sequence = args[0]
             if isinstance(sequence, set):
                 unordered = True
-            elif isinstance(sequence, (Dict, dict)):
+            elif isinstance(sequence, (Dict, Mapping)):
                 unordered = True
                 sequence = sequence.items()
             elif not iterable(sequence):


### PR DESCRIPTION
Fixes #10710. All standard library `dict`-like objects are instances of `Mapping` thus, `OrderedDict`, `ChainMap`, etc., can now be a drop-in replacement for a `dict` in substitutions. Rather than having to wrap the object in a `dict` call.

In Python 3.3 `collections.abc` separated, however to keep compatibility with `sys.version_info < (3,3)`
`from collections import Mapping` works for newer and older versions of Python.